### PR TITLE
chore(ci): change branch to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ esy ]
+    branches: [ master ]
   pull_request:
-    branches: [ esy ]
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
The main branch in the repo we forked from was called `esy`. I changed it back to `master`, and this will update CI to reflect that.