### PR TITLE
fix: run build scripts with bash to avoid them failing with esy nightly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "url": "https://github.com/bryphe/esy-harfbuzz",
   "esy": {
     "build": [
-        ["./esy/prep.sh"],
+        ["bash", "-c", "./esy/prep.sh"],
         ["bash", "-c", "#{os == 'windows' ? './esy/configure-windows.sh' : 'echo'}"],
         ["bash", "-c", "#{os == 'darwin' ? './esy/configure-osx.sh' : 'echo'}"],
         ["bash", "-c", "#{os == 'linux' ? './esy/configure-linux.sh' : 'echo'}"],
-        ["./esy/build.sh"]
+        ["bash", "-c", "./esy/build.sh"]
     ],
     "buildsInSource": "_build",
     "exportedEnv": {


### PR DESCRIPTION
Running build scripts directly fails with esy nightly. Fixed by running them explicitly with bash. Not sure if this is a bug or somehow intentional (@ManasJayanth?), but can't see that being explicit should hurt in any way.